### PR TITLE
Account for empty responses from rest API

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -111,9 +111,10 @@ export default class JiraApi {
     };
 
     const response = await this.request(options);
-
-    if (Array.isArray(response.errorMessages) && response.errorMessages.length > 0) {
-      throw new Error(response.errorMessages.join(', '));
+    if (response) {
+      if (Array.isArray(response.errorMessages) && response.errorMessages.length > 0) {
+        throw new Error(response.errorMessages.join(', '));
+      }
     }
 
     return response;

--- a/test/jira-tests.js
+++ b/test/jira-tests.js
@@ -172,6 +172,21 @@ describe('Jira API Tests', () => {
       await jira.doRequest({})
         .should.eventually.be.rejectedWith('some error to throw, another error');
     });
+
+    it('doRequest does not throw an error on empty response', (done) => {
+      function dummyRequest(requestOptions) {
+        return Promise.resolve(undefined);
+      }
+      const jira = new JiraApi(
+        getOptions({
+          request: dummyRequest
+        })
+      );
+
+      jira.doRequest({})
+        .should.eventually.be.fulfilled
+        .and.notify(done);
+    });
   });
 
   describe('Request Functions Tests', () => {


### PR DESCRIPTION
Sometimes, there is no response during a successful operation from the
JIRA rest API, and this should handle that in the short term.  A better
solution might be to check the status code of the response, and only
check for errors if it is a 4XX or 5XX status code.  This is an attempt
to resolve issue #20