### PR TITLE
Adds support for the version delete operation.

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -340,6 +340,31 @@ export default class JiraApi {
     }));
   }
 
+  /** Delete a version
+   * [Jira Doc](https://docs.atlassian.com/jira/REST/latest/#api/2/version-delete)
+   * @name deleteVersion
+   * @function
+   * @param {string} versionId - the ID of the version to delete
+   * @param {string} moveFixIssuesToId - when provided, existing fixVersions will be moved
+   *                 to this ID. Otherwise, the deleted version will be removed from all
+   *                 issue fixVersions.
+   * @param {string} moveAffectedIssuesToId - when provided, existing affectedVersions will
+   *                 be moved to this ID. Otherwise, the deleted version will be removed
+   *                 from all issue affectedVersions.
+   */
+  deleteVersion(versionId, moveFixIssuesToId, moveAffectedIssuesToId) {
+    return this.doRequest(this.makeRequestHeader(this.makeUri({
+      pathname: `/version/${versionId}`
+    }), {
+      method: 'DELETE',
+      followAllRedirects: true,
+      qs: {
+        moveFixIssuesTo: moveFixIssuesToId,
+        moveAffectedIssuesTo: moveAffectedIssuesToId
+      }
+    }));
+  }
+
   /** Pass a search query to Jira
    * [Jira Doc](https://docs.atlassian.com/jira/REST/latest/#d2e4424)
    * @name searchJira

--- a/test/jira-tests.js
+++ b/test/jira-tests.js
@@ -337,6 +337,15 @@ describe('Jira API Tests', () => {
       result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/version/someVersionId');
     });
 
+    it('deleteVersion hits proper url', async () => {
+      const result = await dummyURLCall('deleteVersion', [
+        'someVersionId',
+        'someFixVersionId',
+        'someAffectedVersionId'
+      ]);
+      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/version/someVersionId?moveFixIssuesTo=someFixVersionId&moveAffectedIssuesTo=someAffectedVersionId');
+    });
+
     it('seachJira hits proper url', async () => {
       const result = await dummyURLCall('searchJira', ['someJQLhere', 'someOptionsObject']);
       result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/search');


### PR DESCRIPTION
Allows for versions to be deleted per [JIRA version delete API](https://docs.atlassian.com/jira/REST/latest/#api/2/version-delete). Verified against local JIRA instance and unit tests pass.