### PR TITLE
`findRapidView` should use the sprint uri not api uri

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -153,12 +153,13 @@ export default class JiraApi {
    * Creates a URI object for a given pathName
    * @param {string} pathname - The url after the /rest/
    */
-  makeSprintQueryUri({ pathname }) {
+  makeSprintQueryUri({ pathname, query }) {
     const uri = url.format({
       protocol: this.protocol,
       hostname: this.host,
       port: this.port,
-      pathname: `${this.base}/rest/greenhopper/${this.greenhopperVersion}${pathname}`
+      pathname: `${this.base}/rest/greenhopper/${this.greenhopperVersion}${pathname}`,
+      query
     });
     return decodeURIComponent(uri);
   }
@@ -267,7 +268,7 @@ export default class JiraApi {
    * @param {string} sprintId - the id for the sprint
    */
   getSprintIssues(rapidViewId, sprintId) {
-    return this.doRequest(this.makeRequestHeader(this.makeUri({
+    return this.doRequest(this.makeRequestHeader(this.makeSprintQueryUri({
       pathname: '/rapid/charts/sprintreport',
       query: {
         rapidViewId,

--- a/src/jira.js
+++ b/src/jira.js
@@ -236,7 +236,7 @@ export default class JiraApi {
    * @param {string} projectName - name for the project
    */
   async findRapidView(projectName) {
-    const response = await this.doRequest(this.makeRequestHeader(this.makeUri({
+    const response = await this.doRequest(this.makeRequestHeader(this.makeSprintQueryUri({
       pathname: '/rapidviews/list'
     })));
 

--- a/test/jira-tests.js
+++ b/test/jira-tests.js
@@ -335,7 +335,7 @@ describe('Jira API Tests', () => {
       }
 
       const result = await dummyURLCall('findRapidView', ['theNameToLookFor'], dummyRequest);
-      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/rapidviews/list');
+      result.should.eql('http://jira.somehost.com:8080/rest/greenhopper/1.0/rapidviews/list');
     });
 
     it('getLastSprintForRapidView hits proper url', async () => {

--- a/test/jira-tests.js
+++ b/test/jira-tests.js
@@ -358,7 +358,7 @@ describe('Jira API Tests', () => {
     it('getSprintIssues hits proper url', async () => {
       const result = await dummyURLCall('getSprintIssues', ['someRapidView', 'someSprintId']);
       result.should
-        .eql('http://jira.somehost.com:8080/rest/api/2.0/rapid/charts/sprintreport?rapidViewId=someRapidView&sprintId=someSprintId');
+        .eql('http://jira.somehost.com:8080/rest/greenhopper/1.0/rapid/charts/sprintreport?rapidViewId=someRapidView&sprintId=someSprintId');
     });
 
     it('addIssueToSprint hits proper url', async () => {


### PR DESCRIPTION
This function should use the greenhopper api rather than the standard rest api (why atlassian why?)

As is this forms the url `https://[host].atlassian.net/rest/api/2/rapidviews/list` but should be `https://[host].atlassian.net/rest/greenhopper/1.0/rapidviews/list`