### PR TITLE
Add parameter to specify resource expansion for findIssue

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -193,10 +193,14 @@ export default class JiraApi {
    * Find an issue in jira
    * [Jira Doc](http://docs.atlassian.com/jira/REST/latest/#id290709)
    * @param {string} issueNumber - The issue number to search for including the project key
+   * @param {string} expand - The resource expansion to return additional fields in the response
    */
-  findIssue(issueNumber) {
+  findIssue(issueNumber, expand) {
     return this.doRequest(this.makeRequestHeader(this.makeUri({
       pathname: `/issue/${issueNumber}`,
+      query: {
+        expand: expand || '',
+      },
     })));
   }
 

--- a/test/jira-tests.js
+++ b/test/jira-tests.js
@@ -315,7 +315,12 @@ describe('Jira API Tests', () => {
 
     it('findIssue hits proper url', async () => {
       const result = await dummyURLCall('findIssue', ['PK-100']);
-      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issue/PK-100');
+      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issue/PK-100?expand=');
+    });
+
+    it('findIssue hits proper url with expansion', async () => {
+      const result = await dummyURLCall('findIssue', ['PK-100', 'transitions,changelog']);
+      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issue/PK-100?expand=transitions,changelog');
     });
 
     it('getUnresolvedIssueCount hits proper url', async () => {


### PR DESCRIPTION
The whole resource expansion concept of JIRA is described here: https://docs.atlassian.com/jira/REST/cloud/#expansion

I want to use this new parameter to be able to fetch the changelog of an issue.