### PR TITLE
Add ability to get all rapid views

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -261,10 +261,12 @@ export default class JiraApi {
       pathname: '/rapidviews/list',
     })));
 
-    const rapidViewResult = response.views
-      .filter(x => x.name.toLowerCase() === projectName.toLowerCase());
+    if (!projectName) return response.views;
 
-    return rapidViewResult[0];
+    const rapidViewResult = response.views
+      .find(x => x.name.toLowerCase() === projectName.toLowerCase());
+
+    return rapidViewResult;
   }
 
   /** Get a list of Sprints belonging to a Rapid View

--- a/src/jira.js
+++ b/src/jira.js
@@ -261,7 +261,7 @@ export default class JiraApi {
       pathname: '/rapidviews/list',
     })));
 
-    if (!projectName) return response.views;
+    if (typeof projectName === 'undefined' || projectName === null) return response.views;
 
     const rapidViewResult = response.views
       .find(x => x.name.toLowerCase() === projectName.toLowerCase());


### PR DESCRIPTION
I've added the ability to get the full list of rapid views if no specific string is provided.  Also noticed `.filter()[0]` being used, optimized by using `.find()`