### PR TITLE
Created `listSprints`

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -269,7 +269,7 @@ export default class JiraApi {
     return rapidViewResult;
   }
 
-  /** Get a list of Sprints belonging to a Rapid View
+  /** Get the most recent sprint for a given rapidViewId
    * @name getLastSprintForRapidView
    * @function
    * @param {string} rapidViewId - the id for the rapid view
@@ -296,6 +296,17 @@ export default class JiraApi {
         rapidViewId,
         sprintId,
       },
+    })));
+  }
+
+  /** Get a list of Sprints belonging to a Rapid View
+   * @name listSprints
+   * @function
+   * @param {string} rapidViewId - the id for the rapid view
+   */
+  listSprints(rapidViewId) {
+    return this.doRequest(this.makeRequestHeader(this.makeSprintQueryUri({
+      pathname: `/sprintquery/${rapidViewId}`,
     })));
   }
 

--- a/test/jira-tests.js
+++ b/test/jira-tests.js
@@ -380,6 +380,13 @@ describe('Jira API Tests', () => {
         .eql('http://jira.somehost.com:8080/rest/greenhopper/1.0/rapid/charts/sprintreport?rapidViewId=someRapidView&sprintId=someSprintId');
     });
 
+    it('listSprints hits proper url', async () => {
+      const result = await dummyURLCall('listSprints', ['someRapidViewId']);
+      result.should.eql(
+        'http://jira.somehost.com:8080/rest/greenhopper/1.0/sprintquery/someRapidViewId'
+      );
+    });
+
     it('addIssueToSprint hits proper url', async () => {
       const result = await dummyURLCall('addIssueToSprint', ['someIssueId', 'someSprintId']);
       result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/sprint/someSprintId/issues/add');


### PR DESCRIPTION
Added `listSprints` to return a list of sprints for a given `rapidViewId`.

Because `getLastSprintForRapidView` states it returns a list of sprints for a given rapidViewId, but does not, I felt the need to update the docs around that fn to be more appropriate.

Also created a test for `listSprints`, kind of a huge learning curve with the test framework, fwiw -- it'd be nice to understand how you've built those a bit better (docs anywhere? &hearts;)

Cheers