### PR TITLE
Fix wrong JQL in getUsersIssues (Issue #149)

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -541,9 +541,9 @@ export default class JiraApi {
    * @param {boolean} open - determines if only open issues should be returned
    */
   getUsersIssues(username, open) {
+    const openJql = open ? ' AND status in (Open, \'In Progress\', Reopened)' : '';
     return this.searchJira(
-      `assignee = ${username.replace('@', '\\u0040')} ` +
-      `AND status in (Open, 'In Progress', Reopened) "${open}"`, {});
+      `assignee = ${username.replace('@', '\\u0040')}${openJql}`, {});
   }
 
   /** Add issue to Jira

--- a/test/jira-tests.js
+++ b/test/jira-tests.js
@@ -458,7 +458,7 @@ describe('Jira API Tests', () => {
     });
 
     it('getUsersIssues hits proper url', async () => {
-      const result = await dummyURLCall('getUsersIssues', ['someUsername', 'true']);
+      const result = await dummyURLCall('getUsersIssues', ['someUsername', true]);
       result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/search');
     });
 


### PR DESCRIPTION
Commit 02319c2deb3 changed getUsersIssues in a way that makes it
generate an invalid JQL. Changing the code back to the original design
(introduced in commit f1417de), where we use the open as a boolean
variable used to decide if we constraint the JQL to return only issues
on an open status or not.