### PR TITLE
Adding Support for Bearer Token

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -35,6 +35,13 @@ export default class JiraApi {
         token_secret: options.oauth.access_token_secret,
         signature_method: options.oauth.signature_method || 'RSA-SHA1',
       };
+    } else if (options.bearer) {
+      this.baseOptions.auth = {
+        user: '',
+        pass: '',
+        sendImmediately: true,
+        bearer: options.bearer
+      };
     } else if (options.username && options.password) {
       this.baseOptions.auth = {
         user: options.username,

--- a/src/jira.js
+++ b/src/jira.js
@@ -40,7 +40,7 @@ export default class JiraApi {
         user: '',
         pass: '',
         sendImmediately: true,
-        bearer: options.bearer
+        bearer: options.bearer,
       };
     } else if (options.username && options.password) {
       this.baseOptions.auth = {


### PR DESCRIPTION
Added the option to supply options.bearer and use a pre-existing Bearer token in the request. This works well with atlassian-oauth2-js module here https://bitbucket.org/atlassian/atlassian-oauth2-js #168 