### PR TITLE
Send unquoted username string in addWatcher request

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -642,7 +642,7 @@ export default class JiraApi {
     }), {
       method: 'POST',
       followAllRedirects: true,
-      body: JSON.stringify(username),
+      body: username,
     }));
   }
 

--- a/test/jira-tests.js
+++ b/test/jira-tests.js
@@ -341,7 +341,7 @@ describe('Jira API Tests', () => {
   });
 
   describe('Request Functions Tests', () => {
-    async function dummyURLCall(jiraApiMethodName, functionArguments, dummyRequestMethod) {
+    async function dummyURLCall(jiraApiMethodName, functionArguments, dummyRequestMethod, returnedValue = 'uri') {
       let dummyRequest = dummyRequestMethod;
       if (!dummyRequest) {
         dummyRequest = async requestOptions => requestOptions;
@@ -363,7 +363,7 @@ describe('Jira API Tests', () => {
         return `${resultObject.uri}?${queryString}`;
       }
 
-      return resultObject.uri;
+      return resultObject[returnedValue];
     }
 
     it('findIssue hits proper url', async () => {
@@ -543,6 +543,11 @@ describe('Jira API Tests', () => {
     it('addWatcher hits proper url', async () => {
       const result = await dummyURLCall('addWatcher', ['ZQ-9001']);
       result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issue/ZQ-9001/watchers');
+    });
+
+    it('addWatcher sends unquoted string in body', async () => {
+      const result = await dummyURLCall('addWatcher', ['ZQ-9001', 'John Smith'], null, 'body');
+      result.should.eql('John Smith');
     });
 
     it('deleteIssue hits proper url', async () => {


### PR DESCRIPTION
## Problem
When you pass username as a string to addWatcher function,  `JSON.stringify` adds additional quotes like '"Some Username"'. Then request library escapes them and we end up with request body similar to  `body: '"\\"Some Username\\""'`, getting `The request sent by the client was syntactically incorrect` error from Jira.

## How to reproduce
Send addWatcher request using node-jira-client v.6.4.0 and Jira v. 6.4.1x 

## Solution
A possible solution is just to omit `JSON.stringify` and rely on request's stringify.

## Tests
This fix works for me with the latest Jira version. I've added a basic test to check the request body, but not sure if it's enough.