### PR TITLE
Add Support for adding comments via comment object

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -948,7 +948,7 @@ export default class JiraApi {
     return this.doRequest(this.makeRequestHeader(this.makeUri({
       pathname: `/issue/${issueId}/comment`,
     }), {
-      body: { comment },
+      body: comment,
       method: 'POST',
       followAllRedirects: true,
     }));

--- a/src/jira.js
+++ b/src/jira.js
@@ -941,9 +941,10 @@ export default class JiraApi {
    * [Jira Doc](https://docs.atlassian.com/jira/REST/latest/#id108798)
    * @name addCommentAdvanced
    * @function
+   * @param {string} issueId - Issue to add a comment to
    * @param {object} comment - The object containing your comment data
    */
-  addCommentAdvanced(comment) {
+  addCommentAdvanced(issueId, comment) {
     return this.doRequest(this.makeRequestHeader(this.makeUri({
       pathname: `/issue/${issueId}/comment`,
     }), {

--- a/src/jira.js
+++ b/src/jira.js
@@ -936,6 +936,22 @@ export default class JiraApi {
       followAllRedirects: true,
     }));
   }
+  
+  /** Add a comment to an issue, supports full comment object
+   * [Jira Doc](https://docs.atlassian.com/jira/REST/latest/#id108798)
+   * @name addCommentAdvanced
+   * @function
+   * @param {object} comment - The object containing your comment data
+   */
+  addCommentAdvanced(comment) {
+    return this.doRequest(this.makeRequestHeader(this.makeUri({
+      pathname: `/issue/${issueId}/comment`,
+    }), {
+      body: { comment },
+      method: 'POST',
+      followAllRedirects: true,
+    }));
+  }
 
   /** Update comment for an issue
    * [Jira Doc](https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-updateComment)

--- a/src/jira.js
+++ b/src/jira.js
@@ -936,7 +936,7 @@ export default class JiraApi {
       followAllRedirects: true,
     }));
   }
-  
+
   /** Add a comment to an issue, supports full comment object
    * [Jira Doc](https://docs.atlassian.com/jira/REST/latest/#id108798)
    * @name addCommentAdvanced

--- a/test/jira-tests.js
+++ b/test/jira-tests.js
@@ -644,6 +644,11 @@ describe('Jira API Tests', () => {
       result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issue/someIssueNumber/comment');
     });
 
+    it('addCommentAdvanced hits proper url', async () => {
+      const result = await dummyURLCall('addCommentAdvanced', ['someIssueNumber', 'someComment']);
+      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issue/someIssueNumber/comment');
+    });
+
     it('updateComment hits proper url', async () => {
       const result = await dummyURLCall('updateComment', ['someIssueNumber', 'someCommentNumber', 'someComment']);
       result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issue/someIssueNumber/comment/someCommentNumber');


### PR DESCRIPTION
Lets you set custom fields and set the visibility before creating the comment.

I've added it as a new function with a new name so it's not breaking.

Ideally it might be worth just swapping the current addComment function to using an object though.


