### PR TITLE
Use '*' as default value for properties

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -293,7 +293,7 @@ export default class JiraApi {
       query: {
         expand: expand || '',
         fields: fields || '*all',
-        properties: properties || '',
+        properties: properties || '*',
         fieldsByKeys: fieldsByKeys || false,
       },
     })));

--- a/test/jira-tests.js
+++ b/test/jira-tests.js
@@ -368,17 +368,17 @@ describe('Jira API Tests', () => {
 
     it('findIssue hits proper url', async () => {
       const result = await dummyURLCall('findIssue', ['PK-100']);
-      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issue/PK-100?expand=&fields=*all&properties=&fieldsByKeys=false');
+      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issue/PK-100?expand=&fields=*all&properties=*&fieldsByKeys=false');
     });
 
     it('findIssue hits proper url with expansion', async () => {
       const result = await dummyURLCall('findIssue', ['PK-100', 'transitions,changelog']);
-      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issue/PK-100?expand=transitions,changelog&fields=*all&properties=&fieldsByKeys=false');
+      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issue/PK-100?expand=transitions,changelog&fields=*all&properties=*&fieldsByKeys=false');
     });
 
     it('findIssue hits proper url with fields', async () => {
       const result = await dummyURLCall('findIssue', ['PK-100', null, 'transitions,changelog']);
-      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issue/PK-100?expand=&fields=transitions,changelog&properties=&fieldsByKeys=false');
+      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issue/PK-100?expand=&fields=transitions,changelog&properties=*&fieldsByKeys=false');
     });
 
     it('findIssue hits proper url with properties', async () => {
@@ -388,7 +388,7 @@ describe('Jira API Tests', () => {
 
     it('findIssue hits proper url with fields and fieldsByKeys', async () => {
       const result = await dummyURLCall('findIssue', ['PK-100', null, 'transitions,changelog', null, true]);
-      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issue/PK-100?expand=&fields=transitions,changelog&properties=&fieldsByKeys=true');
+      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issue/PK-100?expand=&fields=transitions,changelog&properties=*&fieldsByKeys=true');
     });
 
     it('getUnresolvedIssueCount hits proper url', async () => {


### PR DESCRIPTION
Fixes #187 

As decribed in #187, leaving the properties value empty can lead to
internal server error for certain versions of Jira. So '*' is a sensible
default value for this argument.