### PR TITLE
Implement methods for the JIRA Cookie-based Authentication Session REST API

### DIFF
--- a/test/jira-tests.js
+++ b/test/jira-tests.js
@@ -824,6 +824,24 @@ describe('Jira API Tests', () => {
       });
     });
 
+    // Cookie-based Authentication APIs Suite Tests
+    describe('Cookie-based Authentication APIs Suite Tests', () => {
+      it('createSession hits proper url', async () => {
+        const result = await dummyURLCall('createSession', ['someUsername', 'somePassword']);
+        result.should.eql('http://jira.somehost.com:8080/rest/auth/1/session');
+      });
+
+      it('getSession hits proper url', async () => {
+        const result = await dummyURLCall('getSession', []);
+        result.should.eql('http://jira.somehost.com:8080/rest/auth/1/session');
+      });
+
+      it('deleteSession hits proper url', async () => {
+        const result = await dummyURLCall('deleteSession', []);
+        result.should.eql('http://jira.somehost.com:8080/rest/auth/1/session');
+      });
+    });
+
     it('issueNotify hits proper url', async () => {
       const result = await dummyURLCall('issueNotify', ['someIssueId', {}]);
       result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issue/someIssueId/notify');


### PR DESCRIPTION
Implemented methods for the [JIRA Cookie-based Authentication Session REST API](https://developer.atlassian.com/jiradev/jira-apis/jira-rest-apis/jira-rest-api-tutorials/jira-rest-api-example-cookie-based-authentication).

I did NOT hook these new methods into the client's default authentication mechanisms, however, as doing so would require some additional hooks that seem a bit too intrusive for now since it would have to add an actual request _before_ the first request.