### PR TITLE
Adding request to project dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "babel-runtime": "^6.20.0",
+    "request": "^2.83.0",
     "request-promise": "^4.1.1"
   },
   "scripts": {


### PR DESCRIPTION
request is no longer automatically installed by request-promise and needs to be included in the package.