### PR TITLE
New sprint issue end point?!

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -412,13 +412,12 @@ export default class JiraApi {
    * @param {string} sprintId - the id of the sprint to add it to
    */
   addIssueToSprint(issueId, sprintId) {
-    return this.doRequest(this.makeRequestHeader(this.makeUri({
-      pathname: `/sprint/${sprintId}/issues/add`,
+    return this.doRequest(this.makeRequestHeader(this.makeAgileUri({
+      pathname: `/sprint/${sprintId}/issue`,
     }), {
-      method: 'PUT',
-      followAllRedirects: true,
+      method: 'POST',
       body: {
-        issueKeys: [issueId],
+        issues: [issueId],
       },
     }));
   }


### PR DESCRIPTION
I was trying to use the `addIssueToSprint` function and kept getting 404's back from the JIRA API.  After some digging, it looks like it's now located in the agile api with a few minor changes.  I was able to successfully add an issue to a sprint this these updates.

Heres the example from the updated docs:
```
curl --request POST \
  --user email@example.com:<api_token> \
  --header 'Accept: application/json' \
  --header 'Content-Type: application/json' \
  --data '
    {
      "issues": [
        "PR-1",
        "10001",
        "PR-3"
      ]
    }' \
  --url 'https://your-domain.atlassian.net/rest/agile/1.0/sprint/{sprintId}/issue'
```
https://developer.atlassian.com/cloud/jira/software/rest/

Thanks!