### PR TITLE
addWatcher fails on error 400 - undefined

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -668,7 +668,7 @@ export default class JiraApi {
     }), {
       method: 'POST',
       followAllRedirects: true,
-      body: JSON.stringify(username),
+      body: username,
     }));
   }
 


### PR DESCRIPTION
addWatcher doesn't work because we stringify a string and turning 'username' into '"username"'. I removed JSON.stringify and it works as expected.