### PR TITLE
Make newEstimate in addWorklog optional

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -968,7 +968,7 @@ export default class JiraApi {
    * @param {object} newEstimate - the new value for the remaining estimate field
    */
   addWorklog(issueId, worklog, newEstimate = {}) {
-    const query = {};
+    let query = {};
 
     if (Object.keys(newEstimate).length !== 0) {
       query = { adjustEstimate: 'new', newEstimate };
@@ -977,7 +977,7 @@ export default class JiraApi {
     const header = {
       uri: this.makeUri({
         pathname: `/issue/${issueId}/worklog`,
-        query
+        query,
       }),
       body: worklog,
       method: 'POST',

--- a/src/jira.js
+++ b/src/jira.js
@@ -964,14 +964,20 @@ export default class JiraApi {
    * @name addWorklog
    * @function
    * @param {string} issueId - Issue to add a worklog to
-   * @param {object} worklog - worklog object from the rest API
+   * @param {object} [worklog={}] - worklog object from the rest API
    * @param {object} newEstimate - the new value for the remaining estimate field
    */
-  addWorklog(issueId, worklog, newEstimate) {
+  addWorklog(issueId, worklog, newEstimate = {}) {
+    const query = {};
+
+    if (Object.keys(newEstimate).length !== 0) {
+      query = { adjustEstimate: 'new', newEstimate };
+    }
+
     const header = {
       uri: this.makeUri({
         pathname: `/issue/${issueId}/worklog`,
-        query: { adjustEstimate: 'new', newEstimate },
+        query
       }),
       body: worklog,
       method: 'POST',


### PR DESCRIPTION
In JIRA API worklogs are optional, but the wrapper forces the user to set one. Removing it solved the issue for me.