### PR TITLE
Fix GetAllBoards when no projectKeyorId passed

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -1203,7 +1203,7 @@ export default class JiraApi {
         maxResults,
         type,
         name,
-        projectKeyOrId,
+        ...projectKeyOrId && { projectKeyOrId },
       },
     })));
   }


### PR DESCRIPTION
Fix issue on query object instance as previusly projectKeyorId was sent as undefined causing Jira to return boards matching key to '' .

 related #225 