### PR TITLE
Added endpoint for list of worklogs by issueId

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -1115,7 +1115,7 @@ export default class JiraApi {
   getIssueWorklogs(issueId) {
     return this.doRequest(this.makeRequestHeader(
       this.makeUri({
-        pathname: `/issue/${issueId}/worklog`
+        pathname: `/issue/${issueId}/worklog`,
       }),
     ));
   }

--- a/src/jira.js
+++ b/src/jira.js
@@ -1106,6 +1106,20 @@ export default class JiraApi {
     ));
   }
 
+  /** Get worklogs list from a given issue
+   * [Jira Doc](https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-api-3-issue-issueIdOrKey-worklog-get)
+   * @name getIssueWorklogs
+   * @function
+   * @param {string} issueId - the Id of the issue to find worklogs for
+   */
+  getIssueWorklogs(issueId) {
+    return this.doRequest(this.makeRequestHeader(
+      this.makeUri({
+        pathname: `/issue/${issueId}/worklog`
+      }),
+    ));
+  }
+
   /** List all Issue Types jira knows about
    * [Jira Doc](http://docs.atlassian.com/jira/REST/latest/#id295946)
    * @name listIssueTypes

--- a/test/jira-tests.js
+++ b/test/jira-tests.js
@@ -704,6 +704,11 @@ describe('Jira API Tests', () => {
       result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issue/someIssueNumber/worklog/someWorklogId');
     });
 
+    it('getIssueWorklogs hits proper url', async () => {
+      const result = await dummyURLCall('getIssueWorklogs', ['someIssueNumber']);
+      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issue/someIssueNumber/worklog');
+    });
+
     it('listIssueTypes hits proper url', async () => {
       const result = await dummyURLCall('listIssueTypes', []);
       result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/issuetype');


### PR DESCRIPTION
Adding and deleting a worklog already existed, but getting a list of worklogs for a given issue was missing, which is really handy. This just adds a function to GET from the existing JIRA endpoint.