### PR TITLE
Added "query" parameter to searchUsers

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -645,12 +645,13 @@ export default class JiraApi {
    * @param {SearchUserOptions} options
    */
   searchUsers({
-    username, startAt, maxResults, includeActive, includeInactive,
+    username, query, startAt, maxResults, includeActive, includeInactive,
   }) {
     return this.doRequest(this.makeRequestHeader(this.makeUri({
       pathname: '/user/search',
       query: {
         username,
+        query,
         startAt: startAt || 0,
         maxResults: maxResults || 50,
         includeActive: includeActive || true,
@@ -664,7 +665,13 @@ export default class JiraApi {
   /**
    * @typedef SearchUserOptions
    * @type {object}
-   * @property {string} username - A query string used to search username, name or e-mail address
+   * @property {string} username - (DEPRECATED) A query string used to search username, name or
+   * e-mail address
+   * @property {string} query - A query string that is matched against user attributes
+   * (displayName, and emailAddress) to find relevant users. The string can match the prefix of
+   * the attribute's value. For example, query=john matches a user with a displayName of John
+   * Smith and a user with an emailAddress of johnson@example.com. Required, unless accountId
+   * or property is specified.
    * @property {integer} [startAt=0] - The index of the first user to return (0-based)
    * @property {integer} [maxResults=50] - The maximum number of users to return
    * @property {boolean} [includeActive=true] - If true, then active users are included

--- a/test/jira-tests.js
+++ b/test/jira-tests.js
@@ -542,9 +542,10 @@ describe('Jira API Tests', () => {
 
     it('searchUsers hits proper url', async () => {
       const result = await dummyURLCall('searchUsers', [{
+        query: 'someOtherUserName',
         username: 'someUserName',
       }]);
-      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/user/search?username=someUserName&startAt=0&maxResults=50&includeActive=true&includeInactive=false');
+      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/user/search?username=someUserName&query=someOtherUserName&startAt=0&maxResults=50&includeActive=true&includeInactive=false');
     });
 
     it('getUsersInGroup hits proper url', async () => {


### PR DESCRIPTION
Resolves #285 by adding the ability to use the `query` parameter to search for a user as documented in Jira's API for [User Search -> Find users](https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-user-search-get).

Using the "username" parameter is deprecated (although as of this time it is still referenced in the API documentation). It will still work for some people based on their Jira privacy settings, but will eventually be enforced for everyone.

https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/

> Changes to the visibility of user information: Users will be able to restrict the visibility of their personal data through their user profile privacy settings, or in the case of a managed account, the visibility settings that are decided by the site administrator. This means that fields such as email will only be returned by the API if the user has permitted that data to be visible. Note that this means that some fields can be null. The REST API changes will be introduced alongside the existing REST API. The existing REST API will be available until the end of the deprecation period. Until this time, you can use either the GDPR-compliant or non-GDPR compliant version of the REST API. An opt-in mechanism is available which will force Jira Cloud to only use the GDPR-compliant version of the REST API (that is, deprecated data is not used).

Specifically around the [user endpoints](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/#user):

> query parameter must be used to search for a user.