### PR TITLE
Add a method for deleting attachments

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -323,6 +323,19 @@ export default class JiraApi {
   }
 
   /**
+   * @name deleteAttachment
+   * @function
+   * Remove the attachment
+   * [Jira Doc](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/#api-rest-api-3-attachment-id-delete)
+   * @param {string} attachmentId - the attachment id
+   */
+  deleteAttachment(attachmentId) {
+    return this.doRequest(this.makeRequestHeader(this.makeUri({
+      pathname: `/attachment/${attachmentId}`,
+    }), { method: 'DELETE', json: false, encoding: null }));
+  }
+
+  /**
    * @name getUnresolvedIssueCount
    * @function
    * Get the unresolved issue count

--- a/test/jira-tests.js
+++ b/test/jira-tests.js
@@ -412,6 +412,11 @@ describe('Jira API Tests', () => {
       result.should.eql('http://jira.somehost.com:8080/secure/attachment/123456/attachment-%C3%A6%C3%B8%C3%A5.txt');
     });
 
+    it('deleteAttachment hits proper url', async () => {
+      const result = await dummyURLCall('deleteAttachment', ['123456']);
+      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/attachment/123456');
+    });
+
     it('getUnresolvedIssueCount hits proper url', async () => {
       async function dummyRequest(requestOptions) {
         return { issuesUnresolvedCount: requestOptions };


### PR DESCRIPTION
Hello,

I noticed that currently an API does not support the [Delete attachment](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/#api-rest-api-3-attachment-id-delete) method (which was already requested in #296 ), so here is its implementation.