### PR TITLE
fix getIssueChangelog() wrong endpoint

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -1103,10 +1103,11 @@ export default class JiraApi {
    */
   getIssueChangelog(issueNumber, startAt = 0, maxResults = 50) {
     return this.doRequest(this.makeRequestHeader(this.makeUri({
-      pathname: `/issue/${issueNumber}/changelog`,
+      pathname: `/issue/${issueNumber}`,
       query: {
         startAt,
         maxResults,
+        expand: "changelog"
       },
     })));
   }


### PR DESCRIPTION
calling the `getChangelog()` endpoint with an `issueNumber` causes the below error

```
null for uri: https://jira.[company-name].com/rest/api/2/issue/ISSUE-KEY/changelog?startAt=0&maxResults=50
```
This PR fixes the issue by doing the below
1. add `expand` property with value of `changelog` to the query object
2. remove `"/changelog"` path as a suffix to `pathname` `(/issue/${issueNumber/)`

This issue was also present in the dotnet implementation as well, which was fixed using this approach
https://github.com/solidify/jira-azuredevops-migrator/issues/13
