### PR TITLE
Updating deprecated endpoint and surfacing inactive user option

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -752,14 +752,16 @@ export default class JiraApi {
    * @param {string} groupname - A query string used to search users in group
    * @param {integer} [startAt=0] - The index of the first user to return (0-based)
    * @param {integer} [maxResults=50] - The maximum number of users to return (defaults to 50).
+   * @param {boolean} [includeInactiveUsers] - Fetch inactive users too (defaults to false).
    */
-  getUsersInGroup(groupname, startAt = 0, maxResults = 50) {
+  getUsersInGroup(groupname, startAt = 0, maxResults = 50, includeInactiveUsers = false) {
     return this.doRequest(
       this.makeRequestHeader(this.makeUri({
-        pathname: '/group',
+        pathname: '/group/member',
         query: {
           groupname,
           expand: `users[${startAt}:${maxResults}]`,
+          includeInactiveUsers,
         },
       }), {
         followAllRedirects: true,

--- a/src/jira.js
+++ b/src/jira.js
@@ -752,16 +752,14 @@ export default class JiraApi {
    * @param {string} groupname - A query string used to search users in group
    * @param {integer} [startAt=0] - The index of the first user to return (0-based)
    * @param {integer} [maxResults=50] - The maximum number of users to return (defaults to 50).
-   * @param {boolean} [includeInactiveUsers] - Fetch inactive users too (defaults to false).
    */
-  getUsersInGroup(groupname, startAt = 0, maxResults = 50, includeInactiveUsers = false) {
+  getUsersInGroup(groupname, startAt = 0, maxResults = 50) {
     return this.doRequest(
       this.makeRequestHeader(this.makeUri({
-        pathname: '/group/member',
+        pathname: '/group',
         query: {
           groupname,
           expand: `users[${startAt}:${maxResults}]`,
-          includeInactiveUsers,
         },
       }), {
         followAllRedirects: true,

--- a/src/jira.js
+++ b/src/jira.js
@@ -752,7 +752,7 @@ export default class JiraApi {
    * @param {string} groupname - A query string used to search users in group
    * @param {integer} [startAt=0] - The index of the first user to return (0-based)
    * @param {integer} [maxResults=50] - The maximum number of users to return (defaults to 50).
-   * @param {boolean} [includeInactiveUsers=false] - Fetch inactive users too (defaults to false).
+   * @param {boolean} [includeInactiveUsers] - Fetch inactive users too (defaults to false).
    */
   getUsersInGroup(groupname, startAt = 0, maxResults = 50, includeInactiveUsers = false) {
     return this.doRequest(

--- a/src/jira.js
+++ b/src/jira.js
@@ -753,6 +753,9 @@ export default class JiraApi {
    * @param {integer} [startAt=0] - The index of the first user to return (0-based)
    * @param {integer} [maxResults=50] - The maximum number of users to return (defaults to 50).
    */
+  /**
+ * @deprecated
+ */
   getUsersInGroup(groupname, startAt = 0, maxResults = 50) {
     return this.doRequest(
       this.makeRequestHeader(this.makeUri({
@@ -760,6 +763,29 @@ export default class JiraApi {
         query: {
           groupname,
           expand: `users[${startAt}:${maxResults}]`,
+        },
+      }), {
+        followAllRedirects: true,
+      }),
+    );
+  }
+
+  /** Get all members of group on Jira
+   * @name getMembersOfGroup
+   * @function
+   * @param {string} groupname - A query string used to search users in group
+   * @param {integer} [startAt=0] - The index of the first user to return (0-based)
+   * @param {integer} [maxResults=50] - The maximum number of users to return (defaults to 50).
+   * @param {boolean} [includeInactiveUsers=false] - Fetch inactive users too (defaults to false).
+   */
+  getMembersOfGroup(groupname, startAt = 0, maxResults = 50, includeInactiveUsers = false) {
+    return this.doRequest(
+      this.makeRequestHeader(this.makeUri({
+        pathname: '/group/member',
+        query: {
+          groupname,
+          expand: `users[${startAt}:${maxResults}]`,
+          includeInactiveUsers,
         },
       }), {
         followAllRedirects: true,

--- a/src/jira.js
+++ b/src/jira.js
@@ -752,7 +752,7 @@ export default class JiraApi {
    * @param {string} groupname - A query string used to search users in group
    * @param {integer} [startAt=0] - The index of the first user to return (0-based)
    * @param {integer} [maxResults=50] - The maximum number of users to return (defaults to 50).
-   * @param {boolean} [includeInactiveUsers] - Fetch inactive users too (defaults to false).
+   * @param {boolean} [includeInactiveUsers=false] - Fetch inactive users too (defaults to false).
    */
   getUsersInGroup(groupname, startAt = 0, maxResults = 50, includeInactiveUsers = false) {
     return this.doRequest(

--- a/src/jira.js
+++ b/src/jira.js
@@ -752,10 +752,8 @@ export default class JiraApi {
    * @param {string} groupname - A query string used to search users in group
    * @param {integer} [startAt=0] - The index of the first user to return (0-based)
    * @param {integer} [maxResults=50] - The maximum number of users to return (defaults to 50).
+   * @deprecated
    */
-  /**
- * @deprecated
- */
   getUsersInGroup(groupname, startAt = 0, maxResults = 50) {
     return this.doRequest(
       this.makeRequestHeader(this.makeUri({

--- a/test/jira-tests.js
+++ b/test/jira-tests.js
@@ -571,7 +571,7 @@ describe('Jira API Tests', () => {
 
     it('getUsersInGroup hits proper url', async () => {
       const result = await dummyURLCall('getUsersInGroup', ['someGroupName']);
-      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/group?groupname=someGroupName&expand=users[0:50]');
+      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/group/member?groupname=someGroupName&expand=users[0:50]&includeInactiveUsers=false');
     });
 
     it('getUsersIssues hits proper url', async () => {

--- a/test/jira-tests.js
+++ b/test/jira-tests.js
@@ -574,6 +574,11 @@ describe('Jira API Tests', () => {
       result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/group?groupname=someGroupName&expand=users[0:50]');
     });
 
+    it('getMembersOfGroup hits proper url', async () => {
+      const result = await dummyURLCall('getMembersOfGroup', ['someGroupName']);
+      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/group/member?groupname=someGroupName&expand=users[0:50]&includeInactiveUsers=false');
+    });
+
     it('getUsersIssues hits proper url', async () => {
       const result = await dummyURLCall('getUsersIssues', ['someUsername', true]);
       result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/search');

--- a/test/jira-tests.js
+++ b/test/jira-tests.js
@@ -571,7 +571,7 @@ describe('Jira API Tests', () => {
 
     it('getUsersInGroup hits proper url', async () => {
       const result = await dummyURLCall('getUsersInGroup', ['someGroupName']);
-      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/group/member?groupname=someGroupName&expand=users[0:50]&includeInactiveUsers=false');
+      result.should.eql('http://jira.somehost.com:8080/rest/api/2.0/group?groupname=someGroupName&expand=users[0:50]');
     });
 
     it('getUsersIssues hits proper url', async () => {


### PR DESCRIPTION
Group no longer uses its base endpoint, but appends /member - also surfaced the `includeInactiveUsers` option